### PR TITLE
Update linter.py

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -18,8 +18,8 @@ class HamlLint(RubyLinter):
     """Provides an interface to haml-lint."""
 
     syntax = 'ruby haml'
-    cmd = 'haml-lint'
-    version_args = '--version'
+    cmd = 'ruby -S haml-lint'
+    version_args = '-S haml-lint --version'
     version_re = r'(?P<version>\d+\.\d+\.\d+)'
     version_requirement = '>= 0.6.0'
     regex = r'^.+?:(?P<line>\d+) \[(:?(?P<warning>W)|(?P<error>E))\] (?P<message>.+)'


### PR DESCRIPTION
Apply the same syntax than rubocop-linter.
Avoid generate something like :
SublimeLinter: hamllint version query: /Users/yoshyn/.rbenv/shims/ruby /Users/yoshyn/.rbenv/shims/haml-lint --version
