### PR TITLE
Fix an issue with locating Rubocop config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,4 @@ install:
 # command to run tests
 script:
   - flake8 *.py --max-line-length=120
-  - pep257 . --ignore=D202
+  - pep257 . --ignore=D202,D203

--- a/README.md
+++ b/README.md
@@ -28,6 +28,11 @@ In order for `haml-lint` to be executed by SublimeLinter, you must ensure that i
 
 Once you have installed and configured `haml-lint`, you can proceed to install the SublimeLinter-contrib-haml-lint plugin if it is not yet installed.
 
+#### Rubocop config file
+By default the plug-in is looking for `.rubocop.yml` in any of the parent directories
+of the linted file. If your rubocop file is named something else, you can specify
+linter configuration `"rubocop-config": "your_rubocop_file_name.yml"`
+
 ### Plugin installation
 Please use [Package Control][pc] to install the linter plugin. This will ensure that the plugin will be updated when new versions are available. If you want to install from source so you can modify the source code, you probably know what you are doing so we won’t cover that here.
 

--- a/linter.py
+++ b/linter.py
@@ -10,11 +10,11 @@
 
 """This module exports the HamlLint plugin class."""
 
-from SublimeLinter.lint import RubyLinter
+import os
+from SublimeLinter.lint import RubyLinter, util
 
 
 class HamlLint(RubyLinter):
-
     """Provides an interface to haml-lint."""
 
     syntax = 'ruby haml'
@@ -25,3 +25,25 @@ class HamlLint(RubyLinter):
     regex = r'^.+?:(?P<line>\d+) \[(:?(?P<warning>W)|(?P<error>E))\] (?P<message>.+)'
     tempfile_suffix = 'haml'
     config_file = ('--config', '.haml-lint.yml')
+
+    def build_args(self, settings):
+        """
+        Return a list of args to add to cls.cmd.
+
+        We hook into this method to find the rubocop config and set it as an
+        environment variable for the rubocop linter to pick up.
+        """
+        rubocop_file = settings.get('rubocop-config', '.rubocop.yml')
+        if self.filename:
+            rubocop_config = util.find_file(
+                os.path.dirname(self.filename),
+                rubocop_file,
+                aux_dirs='~'
+            )
+            print(rubocop_config)
+            if rubocop_config:
+                self.env['HAML_LINT_RUBOCOP_CONF'] = rubocop_config
+            else:
+                self.env.pop('HAML_LINT_RUBOCOP_CONF', None)
+
+        return super().build_args(settings)


### PR DESCRIPTION
This PR fixes #2 in more or less the same way [SublimeLinter-slim-lint](https://github.com/elstgav/SublimeLinter-slim-lint/blob/master/linter.py) is implemented
