### PR TITLE
corrected gem name to halm_lint with an underscore

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,9 @@ Before using this plugin, you must ensure that `haml-lint` is installed on your 
 
 1. Install `haml-lint` by typing the following in a terminal:
    ```
-   [sudo] gem install haml-lint
+   [sudo] gem install haml_lint
    ```
+   **Note:** Make sure you type `haml_lint` with an underscore (`_`). `gem install haml-lint` will get you an outdated executable.
 
 1. If you are using `rbenv` or `rvm`, ensure that they are loaded in your shell’s correct startup file. See [here](http://sublimelinter.readthedocs.org/en/latest/troubleshooting.html#shell-startup-files) for more information.
 


### PR DESCRIPTION
A change for the documentation to prevent others from running into #4.
