### PR TITLE
Update for SL4

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -20,7 +20,7 @@ class HamlLint(RubyLinter):
     cmd = 'ruby -S haml-lint'
     regex = r'^.+?:(?P<line>\d+) \[(:?(?P<warning>W)|(?P<error>E))\] (?P<message>.+)'
     tempfile_suffix = 'haml'
-    
+
     defaults = {
         '--config': '${folder}/.haml-lint.yml',
         'env': {

--- a/linter.py
+++ b/linter.py
@@ -21,9 +21,9 @@ class HamlLint(RubyLinter):
     regex = r'^.+?:(?P<line>\d+) \[(:?(?P<warning>W)|(?P<error>E))\] (?P<message>.+)'
     tempfile_suffix = 'haml'
     
-    defaults: {
+    defaults = {
+        '--config': '${folder}/.haml-lint.yml',
         'env': {
             'HAML_LINT_RUBOCOP_CONF': '${folder}/.rubocop.yml'
         }
     }
-

--- a/linter.py
+++ b/linter.py
@@ -10,8 +10,7 @@
 
 """This module exports the HamlLint plugin class."""
 
-import os
-from SublimeLinter.lint import RubyLinter, util
+from SublimeLinter.lint import RubyLinter
 
 
 class HamlLint(RubyLinter):
@@ -19,31 +18,12 @@ class HamlLint(RubyLinter):
 
     syntax = 'ruby haml'
     cmd = 'ruby -S haml-lint'
-    version_args = '-S haml-lint --version'
-    version_re = r'(?P<version>\d+\.\d+\.\d+)'
-    version_requirement = '>= 0.6.0'
     regex = r'^.+?:(?P<line>\d+) \[(:?(?P<warning>W)|(?P<error>E))\] (?P<message>.+)'
     tempfile_suffix = 'haml'
-    config_file = ('--config', '.haml-lint.yml')
+    
+    defaults: {
+        'env': {
+            'HAML_LINT_RUBOCOP_CONF': '${folder}/.rubocop.yml'
+        }
+    }
 
-    def build_args(self, settings):
-        """
-        Return a list of args to add to cls.cmd.
-
-        We hook into this method to find the rubocop config and set it as an
-        environment variable for the rubocop linter to pick up.
-        """
-        rubocop_file = settings.get('rubocop-config', '.rubocop.yml')
-        if self.filename:
-            rubocop_config = util.find_file(
-                os.path.dirname(self.filename),
-                rubocop_file,
-                aux_dirs='~'
-            )
-            print(rubocop_config)
-            if rubocop_config:
-                self.env['HAML_LINT_RUBOCOP_CONF'] = rubocop_config
-            else:
-                self.env.pop('HAML_LINT_RUBOCOP_CONF', None)
-
-        return super().build_args(settings)


### PR DESCRIPTION
Users can directly set env variables using the normal settings. Plugins can provide a default for that. 

Here I point 'HAML_LINT_RUBOCOP_CONF' to a std rubo config file sitting in the project root.