### PR TITLE
Fix `cls.syntax` deprecation warning and use `args`

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,10 +34,7 @@ The docs cover [troubleshooting PATH configuration](http://sublimelinter.com/en/
 The default configuration is as follows:
 
 ```
-'--config': '${folder}/.haml-lint.yml',
-'env': {
-    'HAML_LINT_RUBOCOP_CONF': '${folder}/.rubocop.yml'
-} 
+'selector': 'text.haml'
 ```
 
 If you have your configuration files somewhere else or with a different name, set this using the Linter settings.

--- a/linter.py
+++ b/linter.py
@@ -2,7 +2,7 @@
 # linter.py
 # Linter for SublimeLinter3, a code checking framework for Sublime Text 3
 #
-# Written by Jeroen Jacobs
+# Written by Jeroen Jacobs & Tomas Barry
 # Copyright (c) 2014 Jeroen Jacobs
 #
 # License: MIT
@@ -16,14 +16,10 @@ from SublimeLinter.lint import RubyLinter
 class HamlLint(RubyLinter):
     """Provides an interface to haml-lint."""
 
-    syntax = 'ruby haml'
-    cmd = 'ruby -S haml-lint'
+    cmd = 'ruby -S haml-lint ${args} ${temp_file}'
     regex = r'^.+?:(?P<line>\d+) \[(:?(?P<warning>W)|(?P<error>E))\] (?P<message>.+)'
     tempfile_suffix = 'haml'
 
     defaults = {
-        '--config': '${folder}/.haml-lint.yml',
-        'env': {
-            'HAML_LINT_RUBOCOP_CONF': '${folder}/.rubocop.yml'
-        }
+        'selector': 'text.haml'
     }


### PR DESCRIPTION
In Sublime Text 3, there is was a `cls.syntax` deprecation warning in
the console as a result of using:

```python
syntax = 'ruby haml'
```

This removes this warning by using the `selector` configuration:

```python
defaults = {
    'selector': 'text.haml'
}
```

On top of this, it is no longer required to have `.haml-lint.yml`
present and `haml_lint` can make use of the default linting rules.

The `args` and `temp_file` to lint can be specified in the
`SublimeLinter.sublime-settings` file.