### PR TITLE
Use the haml-lint bin instead of calling through ruby

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -16,7 +16,7 @@ from SublimeLinter.lint import RubyLinter
 class HamlLint(RubyLinter):
     """Provides an interface to haml-lint."""
 
-    cmd = 'ruby -S haml-lint ${args} ${temp_file}'
+    cmd = 'haml-lint ${args} ${temp_file}'
     regex = r'^.+?:(?P<line>\d+) \[(:?(?P<warning>W)|(?P<error>E))\] (?P<message>.+)'
     tempfile_suffix = 'haml'
 


### PR DESCRIPTION
Calling `haml-lint` through `ruby -S haml-lint...` is not consistent with the behavior in other linter packages, and thus makes configuration more confusing.

ex: `"executable": ["<ruby version manager>", "exec", "--", "haml-lint"]` in the configuration file results in `/path/to/rbenv exec -- haml-lint -S haml-lint ...`

See https://github.com/SublimeLinter/SublimeLinter-eslint/blob/master/linter.py#L77 and https://github.com/SublimeLinter/SublimeLinter-rubocop/blob/master/linter.py#L40.