### PR TITLE
Pipe from stdin so `InstanceVariables` lints correctly

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -16,9 +16,8 @@ from SublimeLinter.lint import RubyLinter
 class HamlLint(RubyLinter):
     """Provides an interface to haml-lint."""
 
-    cmd = 'haml-lint ${args} ${temp_file}'
+    cmd = 'haml-lint ${args} --stdin ${file}'
     regex = r'^.+?:(?P<line>\d+) \[(:?(?P<warning>W)|(?P<error>E))\] (?P<message>.+)'
-    tempfile_suffix = 'haml'
 
     defaults = {
         'selector': 'text.haml'


### PR DESCRIPTION
Fix #14 by using the somewhat recent addition of the `--stdin` flag to haml-lint