### PR TITLE
Update README.md to reflect haml-lint version requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ SublimeLinter must be installed in order to use this plugin.
 
 Please install via [Package Control](https://packagecontrol.io).
 
-Before using this plugin, ensure that `haml-lint` is installed on your system.
+Before using this plugin, ensure that `haml-lint` (≥0.54.0) is installed on your system.
 To install `haml-lint`, do the following:
 
 1. Install [Ruby](http://www.ruby-lang.org).


### PR DESCRIPTION
Since 6da601dc49 `--stdin` is used, which is not available in `haml-lint` versions <0.54.0 (see [release notes](https://github.com/sds/haml-lint/releases/tag/v0.54.0)). This may lead to an `invalid option: --stdin` error when using older versions. I think we should mention this requirement in the readme.